### PR TITLE
TECH-1643: Fix unused OSGI exported package.

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -34,7 +34,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 
     <properties>
         <jahia-depends>contentRetrieval,default,default-skins,facets,grid,module-manager,profile,serverSettings,skins,tabularList,tags</jahia-depends>
-        <export-package>org.jahia.modules.tasks.rules</export-package>
         <jahia-module-type>templatesSet</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-block-edit-mode>true</jahia-block-edit-mode>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jahia-module-type>templatesSet</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-block-edit-mode>true</jahia-block-edit-mode>
-        <jahia-module-signature>MCwCFHMzgWhjklXvLppRL9cWiCBS5mbZAhQ4MzSO+r0z4VinIQzxpRvPk4mAFA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFGGsrU3yyjyreZT+DEOTKmuKZdmNAhQ0FOVR84nRFYKsJLinaGNKGhu2Tw==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.0.0.0</version>
+        <version>8.2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>templates-system</artifactId>
 	<version>9.1.0-SNAPSHOT</version>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1643

## Description

New OSGI bundle import/export discovery tool has revealed that some useless export package exists in the pom.xml 
It is confirmed that export is not necessary and pom is now fixed including a new signature.

## Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation
