### PR TITLE
TECH-1643: Rollback parent version to 8.0.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.0.0.0</version>
     </parent>
     <artifactId>templates-system</artifactId>
 	<version>9.1.0-SNAPSHOT</version>


### PR DESCRIPTION
Rollback upgrade of maven parent module version : upgrade does not comply with the parent version policy as module still compatible with 8.0.0.0 and has NO specific need of 8.2.0.0