### PR TITLE
fix: Add Categories title for default languages

### DIFF
--- a/src/main/import/repository.xml
+++ b/src/main/import/repository.xml
@@ -153,7 +153,27 @@
             </templates>
 
             <categories jcr:primaryType="jnt:category">
+                <j:translation_de jcr:language="de"
+                                  jcr:mixinTypes="mix:title"
+                                  jcr:primaryType="jnt:translation"
+                                  jcr:title="Categories"/>
                 <j:translation_en jcr:language="en"
+                                  jcr:mixinTypes="mix:title"
+                                  jcr:primaryType="jnt:translation"
+                                  jcr:title="Categories"/>
+                <j:translation_es jcr:language="es"
+                                  jcr:mixinTypes="mix:title"
+                                  jcr:primaryType="jnt:translation"
+                                  jcr:title="Categories"/>
+                <j:translation_it jcr:language="it"
+                                  jcr:mixinTypes="mix:title"
+                                  jcr:primaryType="jnt:translation"
+                                  jcr:title="Categories"/>
+                <j:translation_fr jcr:language="fr"
+                                  jcr:mixinTypes="mix:title"
+                                  jcr:primaryType="jnt:translation"
+                                  jcr:title="Categories"/>
+                <j:translation_pt jcr:language="pt"
                                   jcr:mixinTypes="mix:title"
                                   jcr:primaryType="jnt:translation"
                                   jcr:title="Categories"/>

--- a/src/main/importsite-systemsite/live-repository.xml
+++ b/src/main/importsite-systemsite/live-repository.xml
@@ -15,7 +15,27 @@
         </site-privileged>
       </groups>
       <categories j:originWS="default" j:published="true" jcr:primaryType="jnt:category" jcr:uuid="abd46620-d19a-4fd2-aa7a-d37d41b5952c">
+        <j:translation_de jcr:language="de"
+                          jcr:mixinTypes="mix:title"
+                          jcr:primaryType="jnt:translation"
+                          jcr:title="Categories"/>
         <j:translation_en jcr:language="en"
+                          jcr:mixinTypes="mix:title"
+                          jcr:primaryType="jnt:translation"
+                          jcr:title="Categories"/>
+        <j:translation_es jcr:language="es"
+                          jcr:mixinTypes="mix:title"
+                          jcr:primaryType="jnt:translation"
+                          jcr:title="Categories"/>
+        <j:translation_it jcr:language="it"
+                          jcr:mixinTypes="mix:title"
+                          jcr:primaryType="jnt:translation"
+                          jcr:title="Categories"/>
+        <j:translation_fr jcr:language="fr"
+                          jcr:mixinTypes="mix:title"
+                          jcr:primaryType="jnt:translation"
+                          jcr:title="Categories"/>
+        <j:translation_pt jcr:language="pt"
                           jcr:mixinTypes="mix:title"
                           jcr:primaryType="jnt:translation"
                           jcr:title="Categories"/>
@@ -34,4 +54,3 @@
     </systemsite>
   </sites>
 </content>
-


### PR DESCRIPTION
### Description

We had a regression in the selenium tests where only english had the label `Categories` in the category manager root tree, while other languages defaults to the system name `categories`.

"Fix" by adding translations for default languages. 

Not sure if there's a way to be able to specify a default title other than reverting the change. Or it could be that current behaviour is acceptable as well, and change the tests to reflect that.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
